### PR TITLE
Fix off-by-one when blocking TCP packages with small max segment size

### DIFF
--- a/nftables/firewall/nftables.conf
+++ b/nftables/firewall/nftables.conf
@@ -122,7 +122,7 @@ table inet t_filter {
         tcp flags & (fin|syn|rst|ack) != syn ct state new drop
         tcp flags & (fin|syn|rst|psh|ack|urg) == fin|syn|rst|psh|ack|urg drop
         tcp flags & (fin|syn|rst|psh|ack|urg) == 0x0 drop
-        tcp flags syn tcp option maxseg size 1-536 drop
+        tcp flags syn tcp option maxseg size 1-535 drop
     }
 
     chain blocks {


### PR DESCRIPTION
536 is a valid value (it's even the default value for IPv4 when unspecified). The rule probably intended to block MSS values below 536. Blocking packets with a MSS value of 536 can lead to problems.

See this comment for more details: https://samuel.forestier.app/blog/security/nftables-hardening-rules-and-good-practices#isso-70